### PR TITLE
Add environmental impact and air pollution metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,7 +127,18 @@ HTML_TEMPLATE = '''
             <p>EV CO2 emissions: {{ environmental.ev_emissions }}</p>
             <p>CO2 savings vs petrol: {{ environmental.petrol_savings }} kg</p>
             <p>CO2 savings vs diesel: {{ environmental.diesel_savings }} kg</p>
-            <p><small>Based on Ireland's grid carbon intensity and average new vehicle emissions (2023)</small></p>
+            <h3 style="margin-top: 15px;">Air Quality Impact</h3>
+            <p>NOx emissions avoided:</p>
+            <ul>
+                <li>vs petrol: {{ environmental.petrol_nox_saved }}g</li>
+                <li>vs diesel: {{ environmental.diesel_nox_saved }}g</li>
+            </ul>
+            <p>Particulate Matter (PM) emissions avoided:</p>
+            <ul>
+                <li>vs petrol: {{ environmental.petrol_pm_saved }}g</li>
+                <li>vs diesel: {{ environmental.diesel_pm_saved }}g</li>
+            </ul>
+            <p><small>Based on Ireland's grid carbon intensity and Euro 6 vehicle emission standards (2023)</small></p>
         </div>
     {% endif %}
 </body>
@@ -142,7 +153,7 @@ def calculate_environmental_impact(energy_needed):
         energy_needed (float): Energy needed for charging in kWh
         
     Returns:
-        dict: Environmental impact metrics
+        dict: Environmental impact metrics including CO2 and air pollutants
     """
     # Average CO2 emissions per kWh of electricity in Ireland (2023)
     grid_carbon_intensity = 0.220  # kg CO2/kWh
@@ -153,16 +164,28 @@ def calculate_environmental_impact(energy_needed):
     petrol_emissions_per_km = 0.120  # kg CO2/km (average new car 2023)
     diesel_emissions_per_km = 0.110  # kg CO2/km (average new car 2023)
     
-    # Calculate emissions
+    # Air pollutant emissions per km (mg/km) - Euro 6 standards
+    petrol_nox = 60.0  # mg/km NOx
+    diesel_nox = 80.0  # mg/km NOx
+    petrol_pm = 4.5   # mg/km PM (both PM2.5 and PM10)
+    diesel_pm = 4.5   # mg/km PM (both PM2.5 and PM10)
+    
+    # Calculate CO2 emissions
     ev_emissions = energy_needed * grid_carbon_intensity
     petrol_emissions = ev_range * petrol_emissions_per_km
     diesel_emissions = ev_range * diesel_emissions_per_km
     
-    # Calculate savings
+    # Calculate CO2 savings
     petrol_savings = petrol_emissions - ev_emissions
     diesel_savings = diesel_emissions - ev_emissions
     
-    # Convert to more readable units if small
+    # Calculate air pollutant savings (in grams)
+    petrol_nox_saved = (ev_range * petrol_nox) / 1000  # Convert mg to g
+    diesel_nox_saved = (ev_range * diesel_nox) / 1000
+    petrol_pm_saved = (ev_range * petrol_pm) / 1000
+    diesel_pm_saved = (ev_range * diesel_pm) / 1000
+    
+    # Convert CO2 to more readable units if small
     if ev_emissions < 1:
         ev_emissions_str = f"{ev_emissions * 1000:.1f} g"
     else:
@@ -172,7 +195,11 @@ def calculate_environmental_impact(energy_needed):
         'ev_emissions': ev_emissions_str,
         'ev_range': f"{ev_range:.1f}",
         'petrol_savings': f"{petrol_savings:.2f}",
-        'diesel_savings': f"{diesel_savings:.2f}"
+        'diesel_savings': f"{diesel_savings:.2f}",
+        'petrol_nox_saved': f"{petrol_nox_saved:.1f}",
+        'diesel_nox_saved': f"{diesel_nox_saved:.1f}",
+        'petrol_pm_saved': f"{petrol_pm_saved:.1f}",
+        'diesel_pm_saved': f"{diesel_pm_saved:.1f}"
     }
 
 

--- a/test_app.py
+++ b/test_app.py
@@ -1,5 +1,5 @@
 import unittest
-from app import calculate_charging_time, calculate_costs
+from app import calculate_charging_time, calculate_costs, calculate_environmental_impact
 
 class TestCalculateChargingTime(unittest.TestCase):
     def test_standard_charging_scenario(self):
@@ -143,6 +143,28 @@ class TestCalculateCosts(unittest.TestCase):
         self.assertAlmostEqual(energy_needed, 2.68, places=2)  # 26.8 * 0.1
         self.assertEqual(total_cost, "€0.53")  # 2.68 * (0.16428 * 1.2)
         self.assertEqual(cost_for_full, "€5.28")  # 26.8 * (0.16428 * 1.2)
+
+
+class TestEnvironmentalImpact(unittest.TestCase):
+    """Test environmental impact calculations"""
+    
+    def test_standard_charge_impact(self):
+        """Test environmental impact for a standard charge"""
+        impact = calculate_environmental_impact(16.08)  # 60% of 26.8 kWh battery
+        
+        self.assertEqual(impact['ev_range'], '80.4')  # 16.08 kWh / 0.2 kWh/km
+        self.assertEqual(impact['ev_emissions'], '3.54 kg')  # 16.08 * 0.220
+        self.assertEqual(impact['petrol_savings'], '6.11')  # (80.4 * 0.120) - 3.54
+        self.assertEqual(impact['diesel_savings'], '5.31')  # (80.4 * 0.110) - 3.54
+    
+    def test_small_charge_impact(self):
+        """Test environmental impact for a small charge"""
+        impact = calculate_environmental_impact(2.68)  # 10% of 26.8 kWh battery
+        
+        self.assertEqual(impact['ev_range'], '13.4')  # 2.68 kWh / 0.2 kWh/km
+        self.assertEqual(impact['ev_emissions'], '589.6 g')  # 2.68 * 0.220 * 1000
+        self.assertEqual(impact['petrol_savings'], '1.02')  # (13.4 * 0.120) - 0.5896
+        self.assertEqual(impact['diesel_savings'], '0.88')  # (13.4 * 0.110) - 0.5896
 
 
 if __name__ == '__main__':

--- a/test_app.py
+++ b/test_app.py
@@ -156,6 +156,12 @@ class TestEnvironmentalImpact(unittest.TestCase):
         self.assertEqual(impact['ev_emissions'], '3.54 kg')  # 16.08 * 0.220
         self.assertEqual(impact['petrol_savings'], '6.11')  # (80.4 * 0.120) - 3.54
         self.assertEqual(impact['diesel_savings'], '5.31')  # (80.4 * 0.110) - 3.54
+        
+        # Air pollution savings
+        self.assertEqual(impact['petrol_nox_saved'], '4.8')  # (80.4 * 60.0) / 1000
+        self.assertEqual(impact['diesel_nox_saved'], '6.4')  # (80.4 * 80.0) / 1000
+        self.assertEqual(impact['petrol_pm_saved'], '0.4')   # (80.4 * 4.5) / 1000
+        self.assertEqual(impact['diesel_pm_saved'], '0.4')   # (80.4 * 4.5) / 1000
     
     def test_small_charge_impact(self):
         """Test environmental impact for a small charge"""
@@ -165,6 +171,12 @@ class TestEnvironmentalImpact(unittest.TestCase):
         self.assertEqual(impact['ev_emissions'], '589.6 g')  # 2.68 * 0.220 * 1000
         self.assertEqual(impact['petrol_savings'], '1.02')  # (13.4 * 0.120) - 0.5896
         self.assertEqual(impact['diesel_savings'], '0.88')  # (13.4 * 0.110) - 0.5896
+        
+        # Air pollution savings
+        self.assertEqual(impact['petrol_nox_saved'], '0.8')  # (13.4 * 60.0) / 1000
+        self.assertEqual(impact['diesel_nox_saved'], '1.1')  # (13.4 * 80.0) / 1000
+        self.assertEqual(impact['petrol_pm_saved'], '0.1')   # (13.4 * 4.5) / 1000
+        self.assertEqual(impact['diesel_pm_saved'], '0.1')   # (13.4 * 4.5) / 1000
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds comprehensive environmental impact calculations to the EV Charging Calculator:

## Environmental Impact Features
1. CO2 Emissions:
   - Calculate EV charging emissions using Ireland's grid intensity
   - Compare with petrol and diesel vehicle emissions
   - Show CO2 savings in kg

2. Air Quality Metrics:
   - NOx emissions comparison (Euro 6 standards):
     * Petrol: 60 mg/km
     * Diesel: 80 mg/km
   - Particulate Matter (PM2.5, PM10):
     * Both fuels: 4.5 mg/km
   - Show pollution savings in grams

## UI Improvements
- Added dedicated Air Quality Impact section
- Clear presentation of emissions savings
- Added source information for standards

## Testing
- Added comprehensive tests for all calculations
- Verified both standard and small charge scenarios
- All tests passing

## Technical Details
- Used Euro 6 emission standards (2023)
- All calculations properly documented
- Clean code organization